### PR TITLE
version.py - pd_edits data type

### DIFF
--- a/github2pandas/version.py
+++ b/github2pandas/version.py
@@ -227,7 +227,7 @@ class Version():
 
         pd_edits.rename(columns=Version.EDIT_RENAMING_COLUMNS, inplace = True)
 
-        pd_edits = pd_edits.astype({'total_added_lines' : 'int', 'total_removed_lines' : 'int'})
+        pd_edits = pd_edits.fillna(value=0).astype({'total_added_lines' : 'int', 'total_removed_lines' : 'int'})
 
         # Embed author uuid
         users_ids = Utility.get_users_ids(data_root_dir)

--- a/github2pandas/version.py
+++ b/github2pandas/version.py
@@ -227,6 +227,8 @@ class Version():
 
         pd_edits.rename(columns=Version.EDIT_RENAMING_COLUMNS, inplace = True)
 
+        pd_edits = pd_edits.astype({'total_added_lines' : 'int', 'total_removed_lines' : 'int'})
+
         # Embed author uuid
         users_ids = Utility.get_users_ids(data_root_dir)
         pd_commits['author'] = ""


### PR DESCRIPTION
As described in [this](https://github.com/Ifi-Softwareentwicklung-SoSe2021/softwareentwicklung_aufgabe9_sose2021-somenewteam/issues/5) Issue, I have found a problem with the data types used in the columns `total_added_lines` and `total_removed_lines` of `pd_edits` being mixed strings and ints.

As such I added the filling of `NaN` cells and a conversion of said columns to `int`.